### PR TITLE
Potential fix for code scanning alert no. 55: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/BlindSendFileAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/BlindSendFileAssignment.java
@@ -76,7 +76,7 @@ public class BlindSendFileAssignment implements AssignmentEndpoint, Initializabl
     }
 
     try {
-      Comment comment = comments.parseXml(commentStr, false);
+      Comment comment = comments.parseXml(commentStr, true);
       if (fileContentsForUser.contains(comment.getText())) {
         comment.setText("Nice try, you need to send the file to WebWolf");
       }

--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -70,11 +70,9 @@ public class CommentsCache {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
 
-    // TODO fix me disabled for now.
-    if (securityEnabled) {
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
-    }
+    // Enforce secure XML parsing configurations.
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // Compliant
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Potential fix for [https://github.com/ghas-evaluation/ghas-poc/security/code-scanning/55](https://github.com/ghas-evaluation/ghas-poc/security/code-scanning/55)

To fix the issue, we need to ensure that external DTDs and schemas are always disabled when parsing XML data. This can be achieved by enforcing secure configurations for `XMLInputFactory` and `JAXBContext` regardless of the `securityEnabled` flag. Specifically:
1. Set `XMLConstants.ACCESS_EXTERNAL_DTD` and `XMLConstants.ACCESS_EXTERNAL_SCHEMA` to empty strings to disable external entity resolution.
2. Ensure that the `securityEnabled` flag is always set to `true` when calling the `parseXml` method.

Changes will be made in the `CommentsCache` class to enforce secure XML parsing configurations and in the `BlindSendFileAssignment` class to ensure the `securityEnabled` flag is set to `true`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
