### PR TITLE
Potential fix for code scanning alert no. 55: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -73,6 +73,7 @@ public class CommentsCache {
     // Enforce secure XML parsing configurations.
     xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
     xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // Compliant
+    xif.setProperty("http://apache.org/xml/features/disallow-doctype-decl", true); // Compliant
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Potential fix for [https://github.com/ghas-evaluation/ghas-poc/security/code-scanning/55](https://github.com/ghas-evaluation/ghas-poc/security/code-scanning/55)

To fix the issue, we need to explicitly disable DTD parsing in the `XMLInputFactory` configuration. This can be achieved by setting the `http://apache.org/xml/features/disallow-doctype-decl` feature to `true`. This ensures that the XML parser does not process DTDs, effectively preventing XXE attacks.

**Steps to fix:**
1. Modify the `parseXml` method in `CommentsCache` to include the `disallow-doctype-decl` feature in the `XMLInputFactory` configuration.
2. Ensure that the fix does not alter the existing functionality of the method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
